### PR TITLE
Add MUD URL option to DHCPv6 client

### DIFF
--- a/sys/include/net/dhcpv6.h
+++ b/sys/include/net/dhcpv6.h
@@ -69,6 +69,7 @@ extern "C" {
                                              *   delegation (IA_PD) option */
 #define DHCPV6_OPT_IAPFX            (26U)   /**< IA prefix option */
 #define DHCPV6_OPT_SMR              (82U)   /**< SOL_MAX_RT option */
+#define DHCPV6_OPT_MUD_URL          (112U)  /**< MUD URL option */
 /** @} */
 
 /**

--- a/sys/net/application_layer/dhcpv6/_dhcpv6.h
+++ b/sys/net/application_layer/dhcpv6/_dhcpv6.h
@@ -214,6 +214,17 @@ typedef struct __attribute__((packed)) {
     network_uint32_t value;         /**< overriding value for SOL_MAX_RT (in sec) */
 } dhcpv6_opt_smr_t;
 
+/**
+ * @brief   MUD URL DHCPv6 option format
+ * @see [RFC 8520, section 10]
+ *      (https://tools.ietf.org/html/rfc8520#section-10)
+ */
+typedef struct __attribute__((packed)) {
+    network_uint16_t type;  /**< @ref DHCPV6_OPT_MUD_URL */
+    network_uint16_t len;   /**< length of the MUDstring in octets. */
+    char mudString[];       /**< MUD URL using the "https" scheme */
+} dhcpv6_opt_mud_url_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile
@@ -24,6 +24,8 @@ else
   STATIC_ROUTES ?= 1
 endif
 
+MUD_URL="https://example.org"
+
 # The test requires some setup and to be run as root
 # So it cannot currently be run on CI
 TEST_ON_CI_BLACKLIST += all
@@ -41,6 +43,11 @@ ifeq (1,$(STATIC_ROUTES))
   # `fe80::2`.
   CFLAGS += -DCONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF=3
 endif
+endif
+
+ifdef MUD_URL
+  QUOTATION = "\""
+  CFLAGS += -DMUD_URL=$(QUOTATION)$(MUD_URL)$(QUOTATION)
 endif
 
 ifeq (,$(filter native,$(BOARD)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This contribution adds MUD (Manufacturer Usage Description) support to RIOTs DHCPv6-Client (as defined in [RFC 8520, section 10](https://tools.ietf.org/html/rfc8520#section-10)). If a MUD URL pointing to a MUD file is defined in the makefile, a MUD URL option is added to the DHCP packages sent by the client. This option contains the option code 112, the length of the URL, and the URL itself. 

This information can then be used by a MUD manager at the receiving end to retrieve a so called MUD file (using the MUD URL) and to extract information about the device's intended behavior, especially when it comes to communicating via the internet. Integrating MUD support into RIOT can enhance its capabilities for achieving a more secure Internet of Things.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Using `scapy`, we added a test case under `tests/gnrc_dhcpv6_client_6lbr` that asserts a correct emission of a MUD URL as part of a DHCP option by checking for the corresponding option code (112), the specified `mudString` and the correct option length. The tests can be performed by executing the shell commands `make flash` (or `make all`), followed by `sudo make test` in the `tests/gnrc_dhcpv6_client_6lbr` directory. 

So far, `scapy` does not supported a direct check for the MUD URL option (hence the use of the generic `DHCP6OptUnknown` class) but we succesfully suggested its inclusion in `scapy`'s DHCP module in a [Pull Request](https://github.com/secdev/scapy/pull/2964). We will integrate the new class for the MUD option once a new version of scapy has been released. 

Furthermore, our changes can be tested manually by defining a MUD URL in the makefile under `tests/gnrc_dhcpv6_client_6lbr` or `tests/gnrc_dhcpv6_client/`, running `make all` and `make term`, and verifying the DHCP packages sent using software like Wireshark. When analyzing the packages sent in a network, RIOT devices should emit DHCP packages that contain the MUD option (see the screenshot below) when they are using the DHCP module and have a MUD URL defined.

![Example wireshark DHCP package analysis.](https://hackmd.informatik.uni-bremen.de/uploads/upload_e1e78fa9b24f6f6da4f73d45d4349954.png)

Before performing one of the tests described above, it is necessary to create a tap bridge by running 

```
sudo ./dist/tools/tapsetup/tapsetup
```

inside of RIOT's root directory.

### Issues/PRs references

To our knowledge, MUD or RFC 8520 in general have not been mentioned in any issues or pull requests so far.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->