### PR TITLE
fixup PR: Add MUD URL option to DHCPv6 client 

### DIFF
--- a/sys/include/net/dhcpv6.h
+++ b/sys/include/net/dhcpv6.h
@@ -69,7 +69,7 @@ extern "C" {
                                              *   delegation (IA_PD) option */
 #define DHCPV6_OPT_IAPFX            (26U)   /**< IA prefix option */
 #define DHCPV6_OPT_SMR              (82U)   /**< SOL_MAX_RT option */
-#define DHCPV6_OPT_MUD_URL          (112U)  /**< MUD URL option */
+#define DHCPV6_OPT_MUD_URL          (112U)  /**< MUD URL option (see RFC 8520) */
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
