### PR TITLE
Fix MUD URL datatype in dhcpv6/client.c

### DIFF
--- a/sys/include/net/dhcpv6.h
+++ b/sys/include/net/dhcpv6.h
@@ -69,7 +69,7 @@ extern "C" {
                                              *   delegation (IA_PD) option */
 #define DHCPV6_OPT_IAPFX            (26U)   /**< IA prefix option */
 #define DHCPV6_OPT_SMR              (82U)   /**< SOL_MAX_RT option */
-#define DHCPV6_OPT_MUD_URL          (112U)  /**< MUD URL option */
+#define DHCPV6_OPT_MUD_URL          (112U)  /**< MUD URL option (see RFC 8520) */
 /** @} */
 
 /**

--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -248,7 +248,7 @@ static inline size_t _compose_elapsed_time_opt(dhcpv6_opt_elapsed_time_t *time)
 }
 
 static inline size_t _compose_mud_url_opt(dhcpv6_opt_mud_url_t *mud_url_opt,
-                                          char mud_url[])
+                                          const char *mud_url)
 {
     uint16_t len = strlen(mud_url);
 
@@ -720,7 +720,7 @@ static void _solicit_servers(event_t *event)
                                 ARRAY_SIZE(oro_opts));
 
     #ifdef MUD_URL
-    char mud_url[] = MUD_URL;
+    const char mud_url[] = MUD_URL;
     if (strlen(mud_url) <= 253 && strlen(mud_url) > 0) {
         if (strncmp(mud_url, "https://", 8)==0){
             msg_len += _compose_mud_url_opt((dhcpv6_opt_mud_url_t *)&send_buf[msg_len],


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
